### PR TITLE
Fix cluster name support

### DIFF
--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -1,0 +1,13 @@
+---
+- name: Retrieve current cluster name
+  shell: 'rabbitmqctl cluster_status | grep -oP "Cluster name: \K(.*)"'
+  changed_when: False  # read only
+  check_mode: False
+  register: cluster_name
+  when: rabbitmq_cluster_name | default("", True) != ""
+
+- name: Set cluster name
+  command: "rabbitmqctl set_cluster_name {{ rabbitmq_cluster_name }}"
+  when: >
+    rabbitmq_cluster_name | default("", True) != ""
+    and cluster_name.stdout != rabbitmq_cluster_name

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -27,16 +27,3 @@
     dest: /etc/rabbitmq/rabbitmq-env.conf
   notify: "{{ rabbitmq_restart_handler }}"
   when: rabbitmq_env is defined
-
-- name: Retrieve current cluster name
-  shell: 'rabbitmqctl cluster_status | grep -oP "Cluster name: \K(.*)"'
-  changed_when: False  # read only
-  check_mode: False
-  register: cluster_name
-  when: rabbitmq_cluster_name | default("", True) != ""
-
-- name: Set cluster name
-  command: "rabbitmqctl set_cluster_name {{ rabbitmq_cluster_name }}"
-  when: >
-    rabbitmq_cluster_name | default("", True) != ""
-    and cluster_name.stdout != rabbitmq_cluster_name

--- a/tasks/rabbitmq.yml
+++ b/tasks/rabbitmq.yml
@@ -15,6 +15,8 @@
     enabled: true
     state: started
 
+- include: cluster.yml
+
 - include: vhosts.yml
 
 - include: users.yml


### PR DESCRIPTION
Cluster name operations need to be performed after the Rabbit service is
started.