### PR TITLE
Add RabbitMQ modules node configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ rabbitmq_users:
 | parameter      | required | default | choices | comments |
 | -------------- | -------- | ------- | ------- | -------- |
 | configure_priv | no       | .*      |         |          |
+| node           | no       | rabbit  |         |          |
 | password       | yes      |         |         |          |
 | read_priv      | no       | .*      |         |          |
 | tags           | no       |         |         |          |

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -3,5 +3,6 @@
   rabbitmq_global_parameter:
     name: cluster_name
     value: "{{ rabbitmq_cluster_name | to_json }}"
+    node: "{{ rabbitmq_node_name | default(ansible_env.RABBITMQ_NODENAME) | default('rabbit') }}"
     state: present
   when: rabbitmq_cluster_name | default("", True) != ""

--- a/tasks/policies.yml
+++ b/tasks/policies.yml
@@ -6,7 +6,7 @@
     tags: "{{ item.tags }}"
     state: "{{ item.state | d('present') }}"
     apply_to: "{{ item.apply_to | d(omit) }}"
-    node: "{{ item.node | d(omit) }}"
+    node: "{{ item.node | default(ansible_env.RABBITMQ_NODENAME) | default('rabbit') }}"
     priority: "{{ item.priority | d(omit) }}"
     vhost: "{{ item.vhost | d(omit) }}"
   with_items: "{{ rabbitmq_policies }}"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,7 +1,8 @@
 ---
 - name: remove rabbitmq users
   rabbitmq_user:
-    user: "{{ item }}"
+    user: "{{ item.user | default(item) }}"
+    node: "{{ item.node | default(ansible_env.RABBITMQ_NODENAME) | default('rabbit') }}"
     state: absent
   with_items: "{{ rabbitmq_users_absent }}"
   run_once: "{{ rabbitmq_cluster }}"
@@ -9,6 +10,7 @@
 - name: add rabbitmq users
   rabbitmq_user:
     user: "{{ item.user }}"
+    node: "{{ item.node | default(ansible_env.RABBITMQ_NODENAME) | default('rabbit') }}"
     password: "{{ item.password }}"
     vhost: "{{ item.vhost | default('/') }}"
     configure_priv: "{{ item.configure_priv | default('.*') }}"


### PR DESCRIPTION
This is required when the default rabbit node name is overridden.